### PR TITLE
Development

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ from logging.config import fileConfig
 
 # instantiate flask app
 app = Flask(__name__)
+# JSONIFY throws an error, as Flask tries to access a depecrated method, `request.is_xhr`
+# Update Flask version to solve this more permanently
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 CORS(app)
 app.config['SECRET_KEY'] = config.get('flask', 'secret_key')
@@ -80,7 +82,7 @@ def normalize_eventbrite_status_codes(status):
 def get_dates():
     # retrieves date parameters if given
     # if no date parameters have been given,
-    # use current time - default days in the past (see config) for start_date
+    # will use current time - default days in the past (see config) for start_date
     if request.args.get('start_date'):
         start_date = request.args.get('start_date', datetime.datetime.now(datetime.timezone.utc))
     else: 
@@ -98,13 +100,15 @@ def get_meetings():
     tags = request.args.get('tags', None)
     with open('all_meetings.json') as json_data:
         events_json = json.load(json_data)
-        events_date_filter = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
-        events = filter_events_by_tag(events_date_filter, tags)
-
+        # can events_date_filter be named events instead?
+        # events_date_filter = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
+        events = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
+        events = filter_events_by_tag(events, tags)
         # Sort events by time
         events_json.sort(key=lambda s: s['time'])
+        # return events
         return jsonify(events)
-
+       
 
 if __name__ == '__main__':
     app.run()

--- a/app.py
+++ b/app.py
@@ -100,15 +100,11 @@ def get_meetings():
     tags = request.args.get('tags', None)
     with open('all_meetings.json') as json_data:
         events_json = json.load(json_data)
-        # can events_date_filter be named events instead?
-        # events_date_filter = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
         events = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
         events = filter_events_by_tag(events, tags)
         # Sort events by time
         events_json.sort(key=lambda s: s['time'])
-        # return events
         return jsonify(events)
        
-
 if __name__ == '__main__':
     app.run()

--- a/app.py
+++ b/app.py
@@ -1,22 +1,23 @@
-from flask import Flask, jsonify, request
+from urllib import response
+from flask import Flask, Response
 from flask_cors import CORS
 import simplejson as json
 from configparser import ConfigParser
-# import requests
-import datetime
-import pytz
-from dateutil.parser import parse
+import app_functions as func
+from flask_restful import Api, Resource
 
 # import config file to global object
 config = ConfigParser()
 config_file = 'config.ini'
 config.read(config_file)
 
+
 import logging
 from logging.config import fileConfig
 
 # instantiate flask app
 app = Flask(__name__)
+app.debug = True
 # JSONIFY throws an error, as Flask tries to access a depecrated method, `request.is_xhr`
 # Update Flask version to solve this more permanently
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
@@ -26,85 +27,32 @@ app.config['SECRET_KEY'] = config.get('flask', 'secret_key')
 fileConfig('logging_config.ini')
 logger = logging.getLogger()
 
-# Method used for parsing dates throughout functions
-def parse_date(d):
-    if isinstance(d, datetime.datetime):
-        parsed_date = d
-    elif isinstance(d, str):
-        try:
-            eastern = pytz.timezone('US/Eastern')
-            date_no_tz = parse(d)
-            parsed_date = eastern.localize(date_no_tz, is_dst=None)
-        except ValueError:
-            return 'Start date {} is in unknown format. '.format(d)
-    else:
-        return 'Start date {} is in unknown format. '.format(d)
-    return parsed_date
 
-# Takes list of events and returns list of events occuring in specified date range
-def filter_events_by_date(events, start_date_str=datetime.datetime.now(datetime.timezone.utc), end_date_str=None):
-    start_date = parse_date(start_date_str) if start_date_str else None
-    end_date = parse_date(end_date_str) if end_date_str else None
+api = Api(app)
 
-    if isinstance(start_date, str) or isinstance(end_date, str):
-        return '{}{}'.format(start_date, end_date).replace('None', '')
-
-    if start_date and end_date:
-        return [event for event in events if start_date <= parse(event['time']) <= end_date]
-    elif start_date:
-        return [event for event in events if parse(event['time']) >= start_date]
-    elif end_date:
-        return [event for event in events if parse(event['time']) <= end_date]
-    else:
-        
-        return events
-
-# Takes list of events and string of tags to return list of events with specified tags
-def filter_events_by_tag(events, tags):
-    if tags:
-        tags_list = tags.replace(' ', '').split(',')
-        filtered_events = []
-        for tag in tags_list:
-            filtered_events += [event for event in events if tag in event['tags']]
-        return filtered_events
-    else:
-        return events
-
-def normalize_eventbrite_status_codes(status):
-    # takes current status from eventbrite, and matches it to meetup's vernacular
-    status_dict = {
-        'canceled': 'cancelled',
-        'live': 'upcoming',
-        'ended': 'past'
-    }
-    return status_dict.get(status)
-
-def get_dates():
-    # retrieves date parameters if given
-    # if no date parameters have been given,
-    # will use current time - default days in the past (see config) for start_date
-    if request.args.get('start_date'):
-        start_date = request.args.get('start_date', datetime.datetime.now(datetime.timezone.utc))
-    else: 
-        default_days_in_the_past = config.get('past_events', 'default_days_in_the_past')
-        current_time = (datetime.datetime.utcnow())
-        start_date = (current_time - datetime.timedelta(int(default_days_in_the_past))).strftime('%Y-%m-%d')
-
-    end_date = request.args.get('end_date', None)
-    return start_date, end_date
+@api.representation('application/json')
+def output_json(data, code, headers={"Content-Type": "application/json"}):
+    events_data = json.dumps(data)
+    resp = Response(events_data, status=code, headers=headers)
+    return resp
     
 
-@app.route('/api/gtc', methods=['GET', 'POST'])
-def get_meetings():
-    start_date, end_date = get_dates()
-    tags = request.args.get('tags', None)
-    with open('all_meetings.json') as json_data:
-        events_json = json.load(json_data)
-        events = filter_events_by_date(start_date_str=start_date, end_date_str=end_date, events=events_json)
-        events = filter_events_by_tag(events, tags)
-        # Sort events by time
-        events_json.sort(key=lambda s: s['time'])
-        return jsonify(events)
-       
+@api.representation('application/json+ld')
+def output_json_ld(data, code, headers={"Content-Type": "application/json+ld"}):
+    events_data = func.format_ld_json(data)
+    events_data = json.dumps(events_data)
+    resp = Response(events_data, status=code, headers=headers)
+    return resp
+
+api.representations['application/json+ld'] = output_json_ld
+
+class Event(Resource):
+    def get(self):
+        with open('all_meetings.json') as json_data:
+            events= json.load(json_data)
+        return events
+
+api.add_resource(Event, '/api/gtc')
+
 if __name__ == '__main__':
     app.run()

--- a/app_functions.py
+++ b/app_functions.py
@@ -1,0 +1,163 @@
+import datetime
+from flask import request
+from configparser import ConfigParser
+import pytz
+from dateutil.parser import parse
+
+# import config file to global object
+config = ConfigParser()
+config_file = 'config.ini'
+config.read(config_file)
+
+# Method used for parsing dates throughout functions
+def parse_date(d):
+    if isinstance(d, datetime.datetime):
+        parsed_date = d
+    elif isinstance(d, str):
+        try:
+            eastern = pytz.timezone('US/Eastern')
+            date_no_tz = parse(d)
+            parsed_date = eastern.localize(date_no_tz, is_dst=None)
+        except ValueError:
+            return 'Start date {} is in unknown format. '.format(d)
+    else:
+        return 'Start date {} is in unknown format. '.format(d)
+    return parsed_date
+
+# Takes list of events and returns list of events occuring in specified date range
+def filter_events_by_date(events, start_date_str=datetime.datetime.now(datetime.timezone.utc), end_date_str=None):
+    start_date = parse_date(start_date_str) if start_date_str else None
+    end_date = parse_date(end_date_str) if end_date_str else None
+
+    if isinstance(start_date, str) or isinstance(end_date, str):
+        return '{}{}'.format(start_date, end_date).replace('None', '')
+
+    if start_date and end_date:
+        return [event for event in events if start_date <= parse(event['time']) <= end_date]
+    elif start_date:
+        return [event for event in events if parse(event['time']) >= start_date]
+    elif end_date:
+        return [event for event in events if parse(event['time']) <= end_date]
+    else:
+        
+        return events
+
+# Takes list of events and string of tags to return list of events with specified tags
+def filter_events_by_tag(events, tags):
+    if tags:
+        tags_list = tags.replace(' ', '').split(',')
+        filtered_events = []
+        for tag in tags_list:
+            filtered_events += [event for event in events if tag in event['tags']]
+        return filtered_events
+    else:
+        return events
+
+def get_dates():
+    # retrieves date parameters if given
+    # if no date parameters have been given,
+    # will use current time - default days in the past (see config) for start_date
+    if request.args.get('start_date'):
+        start_date = request.args.get('start_date', datetime.datetime.now(datetime.timezone.utc))
+    else: 
+        default_days_in_the_past = config.get('past_events', 'default_days_in_the_past')
+        current_time = (datetime.datetime.utcnow())
+        start_date = (current_time - datetime.timedelta(int(default_days_in_the_past))).strftime('%Y-%m-%d')
+
+    end_date = request.args.get('end_date', None)
+    return start_date, end_date
+ 
+
+def format_ld_json(events_json):
+    # function reformats all_meetings.json to ld+json 
+    data_feed_elements = []
+    for event in events_json:
+        if event.get('venue') is not None:
+            element = {
+                "@type": "DataFeedItem",
+                "dateCreated": event.get("created_at"), 
+                "dateModified": event.get('data_as_of'),
+                "item": {
+                    "@type": "Event",
+                    "description": event.get('description'), 
+                    "name": event.get('event_name'), 
+                    "organizer": {
+                        "@type": "Organization",
+                        "name": event.get('group_name')
+                            }, 
+                    "nid": event.get('nid'),
+                    "rsvp_count": event.get('rsvp_count'),
+                    "tags": event.get('tags'), 
+                    "startDate": event.get('time'), 
+                    "url": event.get('url'), 
+                    "identifier": f"urn:uuid:{event.get('uuid')}", 
+                    "location":
+                        {
+                        "@type": "Place",
+                        "name": event.get('venue').get('name'),
+                        "address": {
+                        "streetAddress": event.get('venue').get('address'), 
+                        "addressLocality": event.get('venue').get('city'),
+                        "addressRegion": event.get('venue').get('state'),
+                        "addressCountry": event.get('venue').get('country'),
+                        "postalCode": event.get('venue').get('zip')
+                            },
+                        "geo": {
+                            "@type": "GeoCoordinates",
+                            "latitude": event.get('venue').get('lat'),
+                            "longitude": event.get('venue').get('lon'),
+                            }
+                        }
+                    }
+                }
+        else:
+            element = {
+                "@type": "DataFeedItem",
+                "dateCreated": event.get("created_at"), 
+                "dateModified": event.get('data_as_of'),
+                "item": {
+                    "@type": "Event",
+                    "description": event.get('description'), 
+                    "name": event.get('event_name'), 
+                    "organizer": {
+                        "@type": "Organization",
+                        "name": event.get('group_name')
+                            }, 
+                    "nid": event.get('nid'),
+                    "rsvp_count": event.get('rsvp_count'),
+                    "tags": event.get('tags'), 
+                    "startDate": event.get('time'), 
+                    "url": event.get('url'), 
+                    "identifier": f"urn:uuid:{event.get('uuid')}", 
+                    "location":
+                        {
+                        "@type": "Place",
+                        "name": event['venue'],
+                        "address": {
+                        "streetAddress": None, 
+                        "addressLocality": None,
+                        "addressRegion": None,
+                        "addressCountry": None,
+                        "postalCode": None
+                            },
+                        "geo": {
+                            "@type": "GeoCoordinates",
+                            "latitude": None,
+                            "longitude": None,
+                            }
+                        }
+                    }
+                }
+        data_feed_elements.append(element)
+            
+            
+    ld_json = {
+        "@context": [
+                "http://schema.org/",
+                {"nid": None, "rsvp_count": None, "tags": None, "uuid": None}
+                ],
+            "@type": "DataFeed",
+            "dataFeedElement": data_feed_elements
+            
+            }
+    return ld_json

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
     - python-crontab==2.2.6
     - pytz==2017.3
     - flask-cors==3.0.3
+    - flask-restful==0.3.9

--- a/tests.py
+++ b/tests.py
@@ -1,12 +1,13 @@
 import test_fixtures as fixtures
-import app
+import update_functions as app
 import simplejson as json
 import unittest
 import unittest.mock as mock
+import requests
 
 class TestEventList(unittest.TestCase):
     # testing functions in app.py
-
+    
     def test_format_meetup_events(self):
         #function should return a list of dictionaries
         output = app.format_meetup_events(fixtures.meetup_events_list)

--- a/update_cal_data.py
+++ b/update_cal_data.py
@@ -1,17 +1,17 @@
 ##!/home/ubuntu/miniconda2/envs/cal_service/bin/python
 # encoding: utf-8
-import functions as app
+import update_functions as func
 import simplejson as json
 
 # Gets lists of meetings, concatenates meeting lists from all sources, then saves json locally.
 def refresh_all_meetings():
-    group_lists = app.get_group_lists()
-    meetup_events = app.get_meetup_events(group_lists['Meetup.com'])
-    eventbrite_events = app.get_eventbrite_events(group_lists['Eventbrite.com'])
-    eventbrite_venues = app.get_eventbrite_venues(eventbrite_events)
+    group_lists = func.get_group_lists()
+    meetup_events = func.get_meetup_events(group_lists['Meetup.com'])
+    eventbrite_events = func.get_eventbrite_events(group_lists['Eventbrite.com'])
+    eventbrite_venues = func.get_eventbrite_venues(eventbrite_events)
     events = (
-        app.format_meetup_events(meetup_events, group_lists['Meetup.com'])
-        + app.format_eventbrite_events(events_list=eventbrite_events,
+        func.format_meetup_events(meetup_events, group_lists['Meetup.com'])
+        + func.format_eventbrite_events(events_list=eventbrite_events,
                                        venues_list=eventbrite_venues,
                                        group_list=group_lists['Eventbrite.com'])
         )

--- a/update_functions.py
+++ b/update_functions.py
@@ -1,0 +1,233 @@
+import json, datetime, requests
+from configparser import ConfigParser
+
+config = ConfigParser()
+config_file = 'config.ini'
+config.read(config_file)
+
+def get_group_lists():
+    # Queries openupstate API for list of sources , 
+    # organizes them into a set, removing duplicates. 
+    # Returns dictionary of groups with each group source as keys (e.g. 'Meetup', 'Eventbrite', 'Facebook')
+    url = 'https://data.openupstate.org/rest/organizations?org_status=active&_format=json'
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise Exception('Could not connect to OpenUpstate API at {}.  Status Code: {}'.format(url, r.status_code))
+    data = json.loads(r.text)
+    all_sources = [x["field_event_service"] for x in data]
+    all_sources = list(set(all_sources))    # removes duplicates
+    groups_by_source = {}
+    for source in all_sources:
+        groups_by_source[source] = [i for i in data if i['field_event_service'] == source]
+    return groups_by_source
+
+# Takes list of groups and makes API call to Meetup.com to get event details. Returns list.
+def get_meetup_events(group_list):
+    # Extract field_event_api_key from each item in group_list
+    group_apis = [i['field_events_api_key'] for i in group_list]
+    # Create empty list to be returned by the function
+    all_events = []
+
+    max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
+    current_time = datetime.datetime.utcnow()
+    no_earlier_than = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%S.000')
+    
+
+    for api in group_apis:
+        # Create url from group name found in Organization API's field_event_api_key
+        url = 'https://api.meetup.com/{}/events?&sign=true&photo-host=public&no_earlier_than={}&status=upcoming,cancelled,past&page=50'.format(api, no_earlier_than)
+        ## Meetup's API returns paginated results. These results have been limited to the first 50 events.
+
+        r = requests.get(url)
+        if r.status_code != 200:
+            raise Exception('Could not connect to Meetup API at {}.  Status Code: {}'.format(url, r.status_code))
+
+        # Returns one JSON object for each Meetup group, with events nested in the single JSON object
+        data = json.loads(r.text)
+
+        # Extract each event
+        for event in data:
+        # Append individual events to list
+            all_events.append(event)
+        
+    return all_events
+
+def format_meetup_events(events_raw, group_list):
+    # Takes list of events from Meetup and returns formatted list of events
+
+    events = []
+    for event in events_raw:
+        venue_dict = event.get('venue')
+        group_item = [i for i in group_list if i.get('field_events_api_key') == str(event['group']['urlname'])][0]
+        tags = group_item.get('field_org_tags')
+        uuid = group_item.get('uuid')
+        nid = group_item.get('nid')
+
+        if venue_dict:
+            venue = {
+                'name': venue_dict.get('name'),
+                'address': venue_dict.get('address_1'),
+                'city': venue_dict.get('city'),
+                'state': venue_dict.get('state'),
+                'zip': venue_dict.get('zip'),
+                'country': venue_dict.get('country'),
+                'lat': venue_dict.get('lat'),
+                'lon': venue_dict.get('lon')
+            }
+        else:
+            venue = None
+        if event.get('description'):
+            description = event.get('description').replace('<p>', '').replace('</p>', '')
+        else:
+            description = None
+
+        try:
+            event_dict = {
+                'event_name': event.get('name'),
+                'group_name': event.get('group').get('name'),
+                'venue': venue,
+                'url': event.get('link'),
+                # note: time is converted from unix timestamp to ISO 8601 timestamp.
+                # This currently works when both the meeting time and local computer time are in same timezone (US/Eastern).
+                # Unsure if it will work when they are in different timezones.
+                'time': datetime.datetime.utcfromtimestamp(int(event.get('time'))/1000).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'tags': tags,
+                'rsvp_count': event.get('yes_rsvp_count'),
+                'created_at': datetime.datetime.utcfromtimestamp(int(event.get('created'))/1000)
+                                  .strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'description': description,
+                'uuid': uuid,
+                'nid': nid,
+                'data_as_of': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'status': event.get('status')
+            }
+        except TypeError:
+            pass
+
+        events.append(event_dict)
+    return events
+
+# Takes list of groups hosted on EventBrite and returns list of events.
+def get_eventbrite_events(group_list):
+    group_ids = [i['field_events_api_key'] for i in group_list if i['field_events_api_key'] != '']
+    token = config.get('eventbrite', 'token')
+    events = []
+
+    # Number of days to allow for past events
+    max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
+
+    # the current date time in ISO8601 format
+    current_time = (datetime.datetime.utcnow())
+    # the current time minus days in config
+
+    start_date = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%SZ')
+    
+    for group_id in group_ids:
+ 
+        # Eventbrite paginates results with 50 per page. If we do not include a start date then organizers with over
+        # 50 results will only return the oldest results unless we use a continuation token to explicitly page
+        # sorting ascending on the start date will also help ensure the current events aren't lost on pagination if
+        # an organizer happens to have over 50 future events
+        url = 'https://www.eventbriteapi.com/v3/organizers/{}/events/?order_by=start_asc&start_date.range_start={}'.format(group_id, start_date)
+
+        r = requests.get(url, headers={"Authorization": "Bearer {}".format(token)}, verify=True)
+        if r.status_code != 200:
+            raise Exception('Could not connect to Eventbrite API at {}.  Status Code: {}'.format(url, r.status_code))
+        data = json.loads(r.text)
+        if data.get('events'):
+            events_list = data.get('events')
+            events += events_list
+    return events
+
+
+# Takes list of events hosted on EventBrite and returns list of unique venue dictionaries.
+def get_eventbrite_venues(events_list):
+    venue_ids = []
+    token = config.get('eventbrite', 'token')
+    for event in events_list:
+        venue_ids.append(event['venue_id'])
+    venue_ids = list(set(venue_ids))
+    venues = []
+    for venue_id in venue_ids:
+        if venue_id != None:  # Catch exception if venue id not properly supplied
+            url = 'https://www.eventbriteapi.com/v3/venues/{}/'.format(venue_id)
+            r = requests.get(url, headers={"Authorization": "Bearer {}".format(token)}, verify=True)
+            if r.status_code != 200:
+                raise Exception('Could not connect to Eventbrite API at {}.  Status Code: {}'.format(url, r.status_code))
+            data = json.loads(r.text)
+            venues.append(data)
+    return venues
+
+def normalize_eventbrite_status_codes(status):
+    # takes current status from eventbrite, and matches it to meetup's vernacular
+    status_dict = {
+        'canceled': 'cancelled',
+        'live': 'upcoming',
+        'ended': 'past'
+    }
+    return status_dict.get(status)
+
+
+# Takes list of events hosted on EventBrite, list of venues, and list of all groups and returns formatted list of events
+def format_eventbrite_events(events_list, venues_list, group_list):
+
+    venues = {}
+    events = []
+    for venue in venues_list:
+        venue_id = venue.get('id')
+        venue_address = venue.get('address')
+        venue_dict = {}
+        if venue_address:
+            venue_dict = {
+                'name': venue.get('name'),
+                'address': '{}, {}'.format(venue_address.get('address_1'), venue_address.get('address_2')),
+                'city': venue_address.get('city'),
+                'state': venue_address.get('state'),
+                'zip': venue_address.get('postal_code'),
+                'country': venue_address.get('country'),
+                'lat': venue_address.get('latitude'),
+                'lon': venue_address.get('longitude')
+            }
+        venues[venue_id] = venue_dict
+
+    for event in events_list:
+        if type(event.get('venue_id')) == str or event.get('venue_id') is None:  # If venue id error
+            group_item = [i for i in group_list if i['field_events_api_key'] == event.get('organizer_id')][0]
+            group_name = group_item.get('title')
+            tags = group_item.get('field_org_tags')
+            uuid = group_item.get('uuid')
+            nid = group_item.get('nid')
+            if type(event.get('venue_id')) == str:
+                event_dict = {
+                    'event_name': event.get('name').get('text'),
+                    'group_name': group_name,
+                    'venue': venues[event.get('venue_id')],
+                    'url': event.get('url'),
+                    'time': event.get('start').get("utc"),
+                    'tags': tags,
+                    'rsvp_count': None,
+                    'created_at': event.get('created'),
+                    'description': event.get('description').get('text'),
+                    'uuid': uuid,
+                    'nid': nid,
+                    'data_as_of': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'status': normalize_eventbrite_status_codes(event.get('status'))
+                }
+            elif event.get('venue_id') == None: # if event venue is None, it is online/virtual
+                event_dict = {
+                    'event_name': event.get('name').get('text'),
+                    'group_name': group_name,
+                    'venue': event.get('venue_id'),
+                    'url': event.get('url'),
+                    'time': event.get('start').get("utc"),
+                    'tags': tags,
+                    'rsvp_count': None,
+                    'created_at': event.get('created'),
+                    'description': event.get('description').get('text'),
+                    'uuid': uuid,
+                    'nid': nid,
+                    'data_as_of': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'status': normalize_eventbrite_status_codes(event.get('status'))
+                }
+            events.append(event_dict)
+    return events


### PR DESCRIPTION
I've incorporated [Flask-Restful](https://flask-restful.readthedocs.io/en/latest/extending.html) so that requests with `Accept: application/json+ld` will be responded to with a matching content type and JSON-LD formatting as discussed in [Issue 12](https://github.com/codeforgreenville/upstate_tech_cal_service/issues/12) of [Code for Greenville/Upstate_tech_cal_service](https://github.com/codeforgreenville/upstate_tech_cal_service).

The functions that were previously defined in `app.py` have been separated and moved to two files. The functions that are used in `update_cal_data.py` have been moved to file `update_functions.py` and the functions that are used in `app.py` have been moved to file `app_functions.py`. 

The route that was previously defined using Flask's route decorator has been refactored using Flask-RESTful's [Resourceful Routing](https://flask-restful.readthedocs.io/en/latest/quickstart.html#resourceful-routing).